### PR TITLE
fix Array constructor deprecation warning

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -56,4 +56,4 @@ unsafe_convert(::Type{Ptr{T}}, a::StridedArrayView{T}) where {T} = pointer(a)
 
 ## Create similar array
 
-similar(a::StridedArrayView, ::Type{T}, dims::Dims) where {T} = Array(T, dims)
+similar(a::StridedArrayView, ::Type{T}, dims::Dims) where {T} = Array{T}(dims)


### PR DESCRIPTION
Calling `similar` used to cause a deprecation warning because it used the old array constructor `Array(T, dims)`.  This PR changes it to the new array constructor `Array{T}(dim)`.